### PR TITLE
feat: support detecting duplicate labels

### DIFF
--- a/.azure-pipelines/pull-requests/windows.yml
+++ b/.azure-pipelines/pull-requests/windows.yml
@@ -5,7 +5,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
 
 resources:
   repositories:

--- a/letra/_helpers.py
+++ b/letra/_helpers.py
@@ -1,0 +1,24 @@
+from . import Label
+from typing import List
+
+
+def _check_for_duplicate_templates(templates: List[Label]):
+    processed = {}
+    duplicates = {}
+
+    for template in templates:
+        if template.name in processed:
+            duplicates[template.name] = duplicates.get(template.name, 1) + 1
+        else:
+            processed[template.name] = 0
+
+    if duplicates:
+        base_msg = (
+            "Found duplicative label templates. The `name` of each "
+            "label template must be unique.\nDuplicate templates found:\n"
+        )
+        duplicate_msg = ""
+        for label, count in duplicates.items():
+            duplicate_msg = f"{duplicate_msg}{label}: {count} instances\n"
+
+        raise ValueError(f"{base_msg}{duplicate_msg}")

--- a/tests/unit/file_io/test_file_io.py
+++ b/tests/unit/file_io/test_file_io.py
@@ -1,7 +1,7 @@
 from letra._file_io.file_io import (
-    read_templates_from_file,
     get_path_for_read,
     get_path_for_write,
+    read_templates_from_file,
     write_templates_to_file,
 )
 from yaml import FullLoader, YAMLError

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,0 +1,41 @@
+from letra._helpers import _check_for_duplicate_templates
+from letra import Label
+from ..helpers import stub_labels
+from pytest import raises
+
+
+def test__check_for_duplicate_templates_raises_on_duplicates():
+    dup_label = Label(name="dup", description="oops", color="a24b2a")
+    dup_first_copy = Label(name="dup", description="big oops", color="ffffff")
+    dup_second_copy = Label(name="dup", description="so bad", color="aaaaaa")
+    unique_label = Label(name="unique", description="special", color="abcdef")
+    second_dup = Label(
+        name="repeated", description="not again", color="bbbbbb"
+    )
+    second_dup_copy = Label(
+        name="repeated", description="yikes", color="cccccc"
+    )
+
+    templates = [
+        dup_label,
+        second_dup,
+        dup_first_copy,
+        second_dup_copy,
+        unique_label,
+        dup_second_copy,
+    ]
+
+    exp_err = (
+        "Found duplicative label templates. The `name` of each "
+        "label template must be unique.\nDuplicate templates found:\n"
+        f"{dup_label.name}: 3 instances\n"
+        f"{second_dup.name}: 2 instances\n"
+    )
+
+    with raises(ValueError) as err:
+        _check_for_duplicate_templates(templates)
+    assert (str(err.value)) == exp_err
+
+
+def test__check_for_duplicate_templates_does_not_raise_for_unique():
+    _check_for_duplicate_templates(stub_labels)


### PR DESCRIPTION
Closes #49 

Relatively straightforward and small addition here to provide a utility function for detecting duplicate label template definitions within user-supplied input (be it a template file or a list of `Label`'s).

This will avoid any potential of confusing users when they unknowingly have one or more duplicate label keys in their input.  